### PR TITLE
Updates robots.txt to allow NaverBot access

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,15 +1,11 @@
-# 네이버(Yeti / NaverBot 계열)만 허용, 루트 경로(/)만 허용, 그 외 전부 차단
+# 기본: 모든 크롤러 차단
+User-agent: *
+Disallow: /
+
+# 네이버 검색 로봇(Yeti 계열)만 허용
 User-agent: Yeti
 Allow: /$
-Disallow: /
-
-User-agent: NaverBot
-Allow: /$
-Disallow: /
-
-User-agent: NaverBot-Image
-Allow: /$
-Disallow: /
-
-User-agent: *
+Allow: /favicon.ico
+Allow: /*.css$
+Allow: /*.js$
 Disallow: /


### PR DESCRIPTION
Modifies robots.txt to allow NaverBot crawlers
to access the site while blocking all other crawlers except for specific resource types.

This change allows Naver search engine to index the site, improving SEO, while maintaining restricted access for other bots.

## 개요 <!-- 작업 내역 한줄 요약, 스크린샷 등 -->

## 이슈 번호

- closes #n

## 변경사항 <!-- 필수, 상세히 작성(목록화 등)하여 리뷰어에게 도움을 주세요! -->

## 특이사항 <!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->